### PR TITLE
fix: use html/template for SAML POST/Logout templates

### DIFF
--- a/pkg/provider/identityprovider.go
+++ b/pkg/provider/identityprovider.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/zitadel/saml/pkg/provider/serviceprovider"

--- a/pkg/provider/logout_response.go
+++ b/pkg/provider/logout_response.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/xml"
 	"net/http"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/zitadel/saml/pkg/provider/xml/saml"

--- a/pkg/provider/response.go
+++ b/pkg/provider/response.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/zitadel/saml/pkg/provider/xml"

--- a/pkg/provider/template.go
+++ b/pkg/provider/template.go
@@ -1,6 +1,6 @@
 package provider
 
-const postTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+const postTemplate = `
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
 "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
@@ -27,7 +27,7 @@ value="{{ .SAMLResponse }}"/>
 </body>
 </html>`
 
-const logoutTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+const logoutTemplate = `
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
 "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">


### PR DESCRIPTION
Follow up to #29 - Looks like the previous patch was incomplete.

Currently `text/template` is used, which does not properly HTML Encode the HTML Form values used in SAML POST/Logout flows.
Switching to `html/template` resolves this issue.
