### PR TITLE
chore: update go to 1.23

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go: ['1.19', '1.20', '1.21']
+        go: ['1.19', '1.20', '1.21', '1.22', '1.23']
     name: Go ${{ matrix.go }} test
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ Versions that also build are marked with :warning:.
 |---------|--------------------|
 | <1.19   | :x:                |
 | 1.19    | :warning:          |
-| 1.20    | :white_check_mark: |
-| 1.21    | :white_check_mark: |
+| 1.20    | :warning:          |
+| 1.21    | :warning:          |
+| 1.22    | :white_check_mark: |
+| 1.23    | :white_check_mark: |
 
 ## Why another library
 


### PR DESCRIPTION
Add Go 1.23 (and 1.22) to the build matrix and readme.

