### PR TITLE
fix: usage of issuer in specific context

### DIFF
--- a/pkg/provider/attribute_query.go
+++ b/pkg/provider/attribute_query.go
@@ -25,7 +25,7 @@ func (p *IdentityProvider) attributeQueryHandleFunc(w http.ResponseWriter, r *ht
 	var attrQuery *samlp.AttributeQueryType
 	var response *samlp.ResponseType
 
-	metadata, _, err := p.GetMetadata(r)
+	metadata, _, err := p.GetMetadata(r.Context())
 	if err != nil {
 		err := fmt.Errorf("failed to read idp metadata: %w", err)
 		logging.Error(err)
@@ -128,7 +128,7 @@ func (p *IdentityProvider) attributeQueryHandleFunc(w http.ResponseWriter, r *ht
 					queriedAttrs = append(queriedAttrs, queriedAttr)
 				}
 			}
-			response = makeAttributeQueryResponse(attrQuery.Id, p.GetEntityID(r), sp.GetEntityID(), attrs, queriedAttrs, p.TimeFormat, p.Expiration)
+			response = makeAttributeQueryResponse(attrQuery.Id, p.GetEntityID(r.Context()), sp.GetEntityID(), attrs, queriedAttrs, p.TimeFormat, p.Expiration)
 			return nil
 		},
 		func() {

--- a/pkg/provider/context.go
+++ b/pkg/provider/context.go
@@ -14,7 +14,7 @@ import (
 type valueKey int
 
 var (
-	issuer valueKey = 1
+	issuerKey valueKey = 1
 )
 
 type IssuerInterceptor struct {
@@ -44,13 +44,13 @@ func (i *IssuerInterceptor) HandlerFunc(next http.HandlerFunc) http.HandlerFunc 
 // IssuerFromContext reads the issuer from the context (set by an IssuerInterceptor)
 // it will return an empty string if not found
 func IssuerFromContext(ctx context.Context) string {
-	ctxIssuer, _ := ctx.Value(issuer).(string)
+	ctxIssuer, _ := ctx.Value(issuerKey).(string)
 	return ctxIssuer
 }
 
 // ContextWithIssuer returns a new context with issuer set to it.
 func ContextWithIssuer(ctx context.Context, issuer string) context.Context {
-	return context.WithValue(ctx, issuer, issuer)
+	return context.WithValue(ctx, issuerKey, issuer)
 }
 
 func (i *IssuerInterceptor) setIssuerCtx(w http.ResponseWriter, r *http.Request, next http.Handler) {

--- a/pkg/provider/login.go
+++ b/pkg/provider/login.go
@@ -17,7 +17,7 @@ func (p *IdentityProvider) callbackHandleFunc(w http.ResponseWriter, r *http.Req
 		ErrorFunc: func(err error) {
 			http.Error(w, fmt.Errorf("failed to send response: %w", err).Error(), http.StatusInternalServerError)
 		},
-		Issuer: p.GetEntityID(r),
+		Issuer: p.GetEntityID(r.Context()),
 	}
 
 	if err := r.ParseForm(); err != nil {

--- a/pkg/provider/login_test.go
+++ b/pkg/provider/login_test.go
@@ -281,7 +281,7 @@ func TestSSO_loginHandleFunc(t *testing.T) {
 				return
 			}
 
-			idp, err := newTestIdentityProvider(endpoint, tt.args.config, mockStorage, tt.args.issuer)
+			idp, err := newTestIdentityProvider(endpoint, tt.args.config, mockStorage)
 			if (err != nil) != tt.res.err {
 				t.Errorf("NewIdentityProvider() error = %v", err.Error())
 				return
@@ -295,7 +295,7 @@ func TestSSO_loginHandleFunc(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			req := httptest.NewRequest(http.MethodGet, callURL, nil)
-			callHandlerFuncWithIssuerInterceptor(idp.issuerFromRequest, w, req, idp.callbackHandleFunc)
+			callHandlerFuncWithIssuerInterceptor(tt.args.issuer, w, req, idp.callbackHandleFunc)
 
 			res := w.Result()
 			defer func() {

--- a/pkg/provider/logout.go
+++ b/pkg/provider/logout.go
@@ -30,7 +30,7 @@ func (p *IdentityProvider) logoutHandleFunc(w http.ResponseWriter, r *http.Reque
 		ErrorFunc: func(err error) {
 			http.Error(w, fmt.Errorf("failed to send response: %w", err).Error(), http.StatusInternalServerError)
 		},
-		Issuer: p.GetEntityID(r),
+		Issuer: p.GetEntityID(r.Context()),
 	}
 
 	// parse from to get logout request

--- a/pkg/provider/metadata.go
+++ b/pkg/provider/metadata.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
@@ -20,7 +21,7 @@ const (
 )
 
 func (p *Provider) metadataHandle(w http.ResponseWriter, r *http.Request) {
-	metadata, err := p.GetMetadata(r)
+	metadata, err := p.GetMetadata(r.Context())
 	if err != nil {
 		err := fmt.Errorf("error while getting metadata: %w", err)
 		logging.Error(err)
@@ -152,13 +153,13 @@ func (p *IdentityProviderConfig) getMetadata(
 }
 
 func (c *Config) getMetadata(
-	req *http.Request,
+	ctx context.Context,
 	idp *IdentityProvider,
 ) (*md.EntityDescriptorType, error) {
 
 	entity := &md.EntityDescriptorType{
 		XMLName:       xml.Name{Local: "md"},
-		EntityID:      md.EntityIDType(idp.GetEntityID(req)),
+		EntityID:      md.EntityIDType(idp.GetEntityID(ctx)),
 		Id:            NewID(),
 		Signature:     nil,
 		Organization:  nil,
@@ -166,7 +167,7 @@ func (c *Config) getMetadata(
 	}
 
 	if c.IDPConfig != nil {
-		idpMetadata, idpAAMetadata, err := idp.GetMetadata(req)
+		idpMetadata, idpAAMetadata, err := idp.GetMetadata(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -118,7 +118,7 @@ func NewProvider(
 		}
 	}
 
-	idp.issuerFromRequest, err = issuer(prov.insecure)
+	prov.issuerFromRequest, err = issuer(prov.insecure)
 	if err != nil {
 		return nil, err
 	}
@@ -128,12 +128,12 @@ func NewProvider(
 	return prov, nil
 }
 
-func (p *Provider) GetEntityID(r *http.Request) string {
-	return p.identityProvider.GetEntityID(r)
+func (p *Provider) GetEntityID(ctx context.Context) string {
+	return p.identityProvider.GetEntityID(ctx)
 }
 
 func (p *Provider) IssuerFromRequest(r *http.Request) string {
-	return p.identityProvider.issuerFromRequest(r)
+	return p.issuerFromRequest(r)
 }
 
 func NewID() string {
@@ -163,13 +163,13 @@ func (p *Provider) Probes() []ProbesFn {
 	}
 }
 
-func (p *Provider) GetMetadata(req *http.Request) (*md.EntityDescriptorType, error) {
-	metadata, err := p.conf.getMetadata(req, p.identityProvider)
+func (p *Provider) GetMetadata(ctx context.Context) (*md.EntityDescriptorType, error) {
+	metadata, err := p.conf.getMetadata(ctx, p.identityProvider)
 	if err != nil {
 		return nil, err
 	}
 
-	cert, key, err := getMetadataCert(req.Context(), p.storage)
+	cert, key, err := getMetadataCert(ctx, p.storage)
 	if p.conf.MetadataConfig != nil && p.conf.MetadataConfig.SignatureAlgorithm != "" {
 		signer, err := signature.GetSigner(cert, key, p.conf.MetadataConfig.SignatureAlgorithm)
 		if err != nil {
@@ -204,7 +204,7 @@ type HttpInterceptor func(http.Handler) http.Handler
 func CreateRouter(p *Provider, interceptors ...HttpInterceptor) *mux.Router {
 	router := mux.NewRouter()
 
-	router.Use(intercept(p.IssuerFromRequest, interceptors...))
+	router.Use(intercept(p.issuerFromRequest, interceptors...))
 	router.HandleFunc(healthEndpoint, healthHandler)
 	router.HandleFunc(readinessEndpoint, readyHandler(p.Probes()))
 	router.HandleFunc(p.metadataEndpoint.Relative(), p.metadataHandle)

--- a/pkg/provider/sso.go
+++ b/pkg/provider/sso.go
@@ -38,10 +38,10 @@ func (p *IdentityProvider) ssoHandleFunc(w http.ResponseWriter, r *http.Request)
 		ErrorFunc: func(err error) {
 			http.Error(w, fmt.Errorf("failed to send response: %w", err).Error(), http.StatusInternalServerError)
 		},
-		Issuer: p.GetEntityID(r),
+		Issuer: p.GetEntityID(r.Context()),
 	}
 
-	metadata, _, err := p.GetMetadata(r)
+	metadata, _, err := p.GetMetadata(r.Context())
 	if err != nil {
 		err := fmt.Errorf("failed to read idp metadata: %w", err)
 		logging.Error(err)

--- a/pkg/provider/sso_test.go
+++ b/pkg/provider/sso_test.go
@@ -648,7 +648,7 @@ func TestSSO_ssoHandleFunc(t *testing.T) {
 				return
 			}
 
-			idp, err := newTestIdentityProvider(endpoint, tt.args.config, mockStorage, tt.args.issuer)
+			idp, err := newTestIdentityProvider(endpoint, tt.args.config, mockStorage)
 			if (err != nil) != tt.res.err {
 				t.Errorf("NewIdentityProvider() error = %v", err.Error())
 				return
@@ -684,7 +684,7 @@ func TestSSO_ssoHandleFunc(t *testing.T) {
 			}
 
 			w := httptest.NewRecorder()
-			callHandlerFuncWithIssuerInterceptor(idp.issuerFromRequest, w, req, idp.ssoHandleFunc)
+			callHandlerFuncWithIssuerInterceptor(tt.args.issuer, w, req, idp.ssoHandleFunc)
 
 			res := w.Result()
 			defer func() {


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [x] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [x] Critical parts are tested automatically
- [x] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.
