### PR TITLE
fix(metadata): metadata order

### DIFF
--- a/pkg/provider/xml/md/models.go
+++ b/pkg/provider/xml/md/models.go
@@ -150,27 +150,31 @@ type SSODescriptorType struct {
 }
 
 type IDPSSODescriptorType struct {
-	XMLName                    xml.Name                `xml:"urn:oasis:names:tc:SAML:2.0:metadata IDPSSODescriptor"`
-	WantAuthnRequestsSigned    string                  `xml:"WantAuthnRequestsSigned,attr,omitempty"`
-	Id                         string                  `xml:"ID,attr,omitempty"`
-	ValidUntil                 string                  `xml:"validUntil,attr,omitempty"`
-	CacheDuration              string                  `xml:"cacheDuration,attr,omitempty"`
-	ProtocolSupportEnumeration AnyURIListType          `xml:"protocolSupportEnumeration,attr"`
-	ErrorURL                   string                  `xml:"errorURL,attr,omitempty"`
-	SingleSignOnService        []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata SingleSignOnService"`
-	NameIDMappingService       []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata NameIDMappingService"`
-	AssertionIDRequestService  []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata AssertionIDRequestService"`
-	AttributeProfile           []string                `xml:"AttributeProfile"`
-	Attribute                  []*saml.AttributeType   `xml:"Attribute"`
-	ArtifactResolutionService  []IndexedEndpointType   `xml:"urn:oasis:names:tc:SAML:2.0:metadata ArtifactResolutionService"`
-	SingleLogoutService        []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata SingleLogoutService"`
-	ManageNameIDService        []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata ManageNameIDService"`
-	NameIDFormat               []string                `xml:"NameIDFormat"`
-	Signature                  *xml_dsig.SignatureType `xml:"Signature"`
-	Extensions                 *ExtensionsType         `xml:"Extensions"`
-	KeyDescriptor              []KeyDescriptorType     `xml:"KeyDescriptor"`
-	Organization               *OrganizationType       `xml:"Organization"`
-	ContactPerson              []ContactType           `xml:"ContactPerson"`
+	XMLName                    xml.Name       `xml:"urn:oasis:names:tc:SAML:2.0:metadata IDPSSODescriptor"`
+	WantAuthnRequestsSigned    string         `xml:"WantAuthnRequestsSigned,attr,omitempty"`
+	Id                         string         `xml:"ID,attr,omitempty"`
+	ValidUntil                 string         `xml:"validUntil,attr,omitempty"`
+	CacheDuration              string         `xml:"cacheDuration,attr,omitempty"`
+	ProtocolSupportEnumeration AnyURIListType `xml:"protocolSupportEnumeration,attr"`
+	ErrorURL                   string         `xml:"errorURL,attr,omitempty"`
+
+	// DO NOT CHANGE THE ORDER OF THESE PARAMS.
+	// See https://groups.oasis-open.org/higherlogic/ws/public/download/51890/SAML%20MD%20simplified%20overview.pdf/latest chapter 2.10
+	Extensions                *ExtensionsType       `xml:"Extensions"`
+	KeyDescriptor             []KeyDescriptorType   `xml:"KeyDescriptor"`
+	ArtifactResolutionService []IndexedEndpointType `xml:"urn:oasis:names:tc:SAML:2.0:metadata ArtifactResolutionService"`
+	SingleLogoutService       []EndpointType        `xml:"urn:oasis:names:tc:SAML:2.0:metadata SingleLogoutService"`
+	NameIDFormat              []string              `xml:"NameIDFormat"`
+	SingleSignOnService       []EndpointType        `xml:"urn:oasis:names:tc:SAML:2.0:metadata SingleSignOnService"`
+
+	NameIDMappingService      []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata NameIDMappingService"`
+	AssertionIDRequestService []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata AssertionIDRequestService"`
+	AttributeProfile          []string                `xml:"AttributeProfile"`
+	Attribute                 []*saml.AttributeType   `xml:"Attribute"`
+	ManageNameIDService       []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata ManageNameIDService"`
+	Signature                 *xml_dsig.SignatureType `xml:"Signature"`
+	Organization              *OrganizationType       `xml:"Organization"`
+	ContactPerson             []ContactType           `xml:"ContactPerson"`
 	//InnerXml                   string                  `xml:",innerxml"`
 }
 

--- a/pkg/provider/xml/md/models.go
+++ b/pkg/provider/xml/md/models.go
@@ -167,14 +167,16 @@ type IDPSSODescriptorType struct {
 	NameIDFormat              []string              `xml:"NameIDFormat"`
 	SingleSignOnService       []EndpointType        `xml:"urn:oasis:names:tc:SAML:2.0:metadata SingleSignOnService"`
 
-	NameIDMappingService      []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata NameIDMappingService"`
-	AssertionIDRequestService []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata AssertionIDRequestService"`
-	AttributeProfile          []string                `xml:"AttributeProfile"`
-	Attribute                 []*saml.AttributeType   `xml:"Attribute"`
-	ManageNameIDService       []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata ManageNameIDService"`
-	Signature                 *xml_dsig.SignatureType `xml:"Signature"`
-	Organization              *OrganizationType       `xml:"Organization"`
-	ContactPerson             []ContactType           `xml:"ContactPerson"`
+	NameIDMappingService      []EndpointType `xml:"urn:oasis:names:tc:SAML:2.0:metadata NameIDMappingService"`
+	AssertionIDRequestService []EndpointType `xml:"urn:oasis:names:tc:SAML:2.0:metadata AssertionIDRequestService"`
+
+	// AttributeProfile MUST be before Attribute
+	AttributeProfile    []string                `xml:"AttributeProfile"`
+	Attribute           []*saml.AttributeType   `xml:"Attribute"`
+	ManageNameIDService []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata ManageNameIDService"`
+	Signature           *xml_dsig.SignatureType `xml:"Signature"`
+	Organization        *OrganizationType       `xml:"Organization"`
+	ContactPerson       []ContactType           `xml:"ContactPerson"`
 	//InnerXml                   string                  `xml:",innerxml"`
 }
 
@@ -258,22 +260,27 @@ type PDPDescriptorType struct {
 }
 
 type AttributeAuthorityDescriptorType struct {
-	XMLName                    xml.Name                `xml:"urn:oasis:names:tc:SAML:2.0:metadata AttributeAuthorityDescriptor"`
-	Id                         string                  `xml:"ID,attr,omitempty"`
-	ValidUntil                 string                  `xml:"validUntil,attr,omitempty"`
-	CacheDuration              string                  `xml:"cacheDuration,attr,omitempty"`
-	ProtocolSupportEnumeration AnyURIListType          `xml:"protocolSupportEnumeration,attr"`
-	ErrorURL                   string                  `xml:"errorURL,attr,omitempty"`
-	AttributeService           []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata AttributeService"`
-	AssertionIDRequestService  []EndpointType          `xml:"urn:oasis:names:tc:SAML:2.0:metadata AssertionIDRequestService"`
-	NameIDFormat               []string                `xml:"NameIDFormat"`
-	AttributeProfile           []string                `xml:"AttributeProfile"`
-	Attribute                  []*saml.AttributeType   `xml:"Attribute"`
-	Signature                  *xml_dsig.SignatureType `xml:"Signature"`
-	Extensions                 *ExtensionsType         `xml:"Extensions"`
-	KeyDescriptor              []KeyDescriptorType     `xml:"KeyDescriptor"`
-	Organization               *OrganizationType       `xml:"Organization"`
-	ContactPerson              []ContactType           `xml:"ContactPerson"`
+	XMLName                    xml.Name       `xml:"urn:oasis:names:tc:SAML:2.0:metadata AttributeAuthorityDescriptor"`
+	Id                         string         `xml:"ID,attr,omitempty"`
+	ValidUntil                 string         `xml:"validUntil,attr,omitempty"`
+	CacheDuration              string         `xml:"cacheDuration,attr,omitempty"`
+	ProtocolSupportEnumeration AnyURIListType `xml:"protocolSupportEnumeration,attr"`
+	ErrorURL                   string         `xml:"errorURL,attr,omitempty"`
+
+	// DO NOT CHANGE THE ORDER OF THESE PARAMS.
+	// See https://groups.oasis-open.org/higherlogic/ws/public/download/51890/SAML%20MD%20simplified%20overview.pdf/latest chapter 2.1
+	KeyDescriptor    []KeyDescriptorType `xml:"KeyDescriptor"`
+	AttributeService []EndpointType      `xml:"urn:oasis:names:tc:SAML:2.0:metadata AttributeService"`
+	NameIDFormat     []string            `xml:"NameIDFormat"`
+
+	AssertionIDRequestService []EndpointType `xml:"urn:oasis:names:tc:SAML:2.0:metadata AssertionIDRequestService"`
+	// AttributeProfile MUST be before Attribute
+	AttributeProfile []string                `xml:"AttributeProfile"`
+	Attribute        []*saml.AttributeType   `xml:"Attribute"`
+	Signature        *xml_dsig.SignatureType `xml:"Signature"`
+	Extensions       *ExtensionsType         `xml:"Extensions"`
+	Organization     *OrganizationType       `xml:"Organization"`
+	ContactPerson    []ContactType           `xml:"ContactPerson"`
 	//InnerXml                   string                  `xml:",innerxml"`
 }
 


### PR DESCRIPTION
### Definition of Ready

- [x] I am happy with the code
- [x] Short description of the feature/issue is added in the pr description
- [x] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [x] All open todos and follow ups are defined in a new ticket and justified
- [x] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [x] No debug or dead code
- [x] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [x] Documentation/examples are up-to-date
- [x] All non-functional requirements are met
- [x] Functionality of the acceptance criteria is checked manually on the dev system.

# Which problems are fixed

This change is addressing the issue https://github.com/zitadel/zitadel/issues/5630 , specifically the part **"Order of SAML attributes are non-compliant"** .

# How are problems are fixed

The change entails changing the order of the parameters of the 2 structs `IDPSSODescriptorType` and `AttributeAuthorityDescriptorType` according to what is described in https://groups.oasis-open.org/higherlogic/ws/public/download/51890/SAML%20MD%20simplified%20overview.pdf/latest and https://shibboleth.atlassian.net/wiki/spaces/CONCEPT/pages/928645275/MetadataForIdP

# References

  - Partially addresses https://github.com/zitadel/zitadel/issues/5630