### PR TITLE
chore: replace deprecated labels with issue types in templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,6 +2,7 @@
 name: 🐛 Bug report
 about: Create a report to help us improve
 title: ''
+type: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,6 @@
 name: 🐛 Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,6 +2,7 @@
 name: 🚀 Feature request
 about: Suggest an idea for this project
 title: ''
+type: enhancement
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,6 @@
 name: 🚀 Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description

The org is migrating from label-based issue classification to GitHub Issue Types. Issue templates that hardcode `labels:` would silently re-add those labels every time an issue is opened, blocking the cleanup.

This PR replaces the deprecated hardcoded labels with the corresponding issue `type:`:

- `.github/ISSUE_TEMPLATE/bug_report.md` — `labels: bug` → `type: bug`
- `.github/ISSUE_TEMPLATE/feature_request.md` — `labels: enhancement` → `type: enhancement`

No other `type:` lines, body fields, or labels were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)