### PR TITLE
fix(provider): reject SAML requests without an issuer

### DIFF
--- a/pkg/provider/logout.go
+++ b/pkg/provider/logout.go
@@ -76,6 +76,17 @@ func (p *IdentityProvider) logoutHandleFunc(w http.ResponseWriter, r *http.Reque
 		},
 	)
 
+	// ensure the issuer exists since it identifies the service provider
+	checkerInstance.WithLogicStep(
+		func() error {
+			err = checkIssuerPresent(logoutRequest.Issuer)
+			return err
+		},
+		func() {
+			response.sendBackLogoutResponse(w, response.makeFailedLogoutResponse(StatusCodeRequestDenied, fmt.Errorf("failed to validate request: %w", err).Error(), p.TimeFormat))
+		},
+	)
+
 	// get persisted service provider from issuer out of the request
 	checkerInstance.WithLogicStep(
 		func() error {
@@ -108,7 +119,13 @@ func (p *IdentityProvider) logoutHandleFunc(w http.ResponseWriter, r *http.Reque
 		w,
 		response.makeSuccessfulLogoutResponse(p.TimeFormat),
 	)
-	logging.Info(fmt.Sprintf("logout request for user %s", logoutRequest.NameID.Text))
+
+	if logoutRequest.NameID != nil {
+		logging.Info(fmt.Sprintf("logout request for user %s", logoutRequest.NameID.Text))
+		return
+	}
+
+	logging.Info(fmt.Sprintf("logout request without NameID from issuer %s", logoutRequest.Issuer.Text))
 }
 
 func getLogoutRequestFromRequest(r *http.Request) (*LogoutRequestForm, error) {

--- a/pkg/provider/logout_test.go
+++ b/pkg/provider/logout_test.go
@@ -1,0 +1,118 @@
+package provider
+
+import (
+	"encoding/base64"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	dsig "github.com/russellhaering/goxmldsig"
+
+	"github.com/zitadel/saml/pkg/provider/serviceprovider"
+	"github.com/zitadel/saml/pkg/provider/xml/samlp"
+)
+
+func TestLogout_logoutHandleFunc(t *testing.T) {
+	type res struct {
+		code  int
+		state string
+	}
+	tests := []struct {
+		name        string
+		samlRequest string
+		sp          bool
+		res         res
+	}{
+		{
+			name: "request without NameID",
+			sp:   true,
+			samlRequest: base64.StdEncoding.EncodeToString([]byte(compactXML(`<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="id-no-nameid" Version="2.0" IssueInstant="2024-01-01T00:00:00Z" Destination="http://localhost:50002/saml/SLO">
+				<saml:Issuer>http://localhost:8000/saml/metadata</saml:Issuer>
+			</samlp:LogoutRequest>`))),
+			res: res{
+				code:  200,
+				state: StatusCodeSuccess,
+			},
+		},
+		{
+			name: "request without issuer",
+			samlRequest: base64.StdEncoding.EncodeToString([]byte(compactXML(`<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="id-no-issuer" Version="2.0" IssueInstant="2024-01-01T00:00:00Z" Destination="http://localhost:50002/saml/SLO">
+			</samlp:LogoutRequest>`))),
+			res: res{
+				code:  200,
+				state: StatusCodeRequestDenied,
+			},
+		},
+		{
+			name: "request with empty issuer",
+			samlRequest: base64.StdEncoding.EncodeToString([]byte(compactXML(`<samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="id-empty-issuer" Version="2.0" IssueInstant="2024-01-01T00:00:00Z" Destination="http://localhost:50002/saml/SLO">
+				<saml:Issuer></saml:Issuer>
+			</samlp:LogoutRequest>`))),
+			res: res{
+				code:  200,
+				state: StatusCodeRequestDenied,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &IdentityProviderConfig{
+				SignatureAlgorithm: dsig.RSASHA256SignatureMethod,
+				MetadataIDPConfig:  &MetadataIDPConfig{},
+				Endpoints: &EndpointConfig{
+					SingleLogOut: getEndpointPointer("/saml/SLO", "http://localhost:50002/saml/SLO"),
+				},
+			}
+			mockStorage := idpStorageWithResponseCert(t, []byte(""), []byte(""))
+
+			if tt.sp {
+				entityID := "http://localhost:8000/saml/metadata"
+				metadata := compactXML(`<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:8000/saml/metadata">
+				  <SPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false" WantAssertionsSigned="true">
+				    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8000/saml/acs" index="1"/>
+				  </SPSSODescriptor>
+				</EntityDescriptor>`)
+				spInst, err := serviceprovider.NewServiceProvider(entityID, &serviceprovider.Config{Metadata: []byte(metadata)}, func(s string) string { return "" })
+				if err != nil {
+					t.Fatalf("error while creating service provider: %v", err)
+				}
+				mockStorage.EXPECT().GetEntityByID(gomock.Any(), entityID).Return(spInst, nil).Times(1)
+			}
+
+			idp, err := newTestIdentityProvider(NewEndpoint("/saml/metadata"), config, mockStorage)
+			if err != nil {
+				t.Fatalf("NewIdentityProvider() error = %v", err)
+			}
+
+			form := url.Values{}
+			form.Add("SAMLRequest", tt.samlRequest)
+			req := httptest.NewRequest(http.MethodPost, idp.endpoints.singleLogoutEndpoint.Relative(), nil)
+			req.Form = form
+
+			w := httptest.NewRecorder()
+			callHandlerFuncWithIssuerInterceptor("http://localhost:50002", w, req, idp.logoutHandleFunc)
+
+			result := w.Result()
+			defer func() { _ = result.Body.Close() }()
+			body, err := io.ReadAll(result.Body)
+			if err != nil {
+				t.Fatalf("failed to read response body: %v", err)
+			}
+			if result.StatusCode != tt.res.code {
+				t.Fatalf("logoutHandleFunc() code got = %v, want %v", result.StatusCode, tt.res.code)
+			}
+
+			response := &samlp.LogoutResponseType{}
+			if err := xml.Unmarshal(body, response); err != nil {
+				t.Fatalf("failed to decode logout response: %v", err)
+			}
+			if response.Status.StatusCode.Value != tt.res.state {
+				t.Errorf("logoutHandleFunc() status got = %v, want %v", response.Status.StatusCode.Value, tt.res.state)
+			}
+		})
+	}
+}

--- a/pkg/provider/sso.go
+++ b/pkg/provider/sso.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zitadel/saml/pkg/provider/serviceprovider"
 	"github.com/zitadel/saml/pkg/provider/xml"
 	"github.com/zitadel/saml/pkg/provider/xml/md"
+	"github.com/zitadel/saml/pkg/provider/xml/saml"
 	"github.com/zitadel/saml/pkg/provider/xml/samlp"
 	"github.com/zitadel/saml/pkg/provider/xml/xml_dsig"
 )
@@ -97,6 +98,17 @@ func (p *IdentityProvider) ssoHandleFunc(w http.ResponseWriter, r *http.Request)
 		},
 		func() {
 			response.sendBackResponse(r, w, response.makeFailedResponse(StatusCodeRequestDenied, fmt.Errorf("failed to decode request").Error(), p.TimeFormat))
+		},
+	)
+
+	// ensure the issuer exists since it identifies the service provider
+	checkerInstance.WithLogicStep(
+		func() error {
+			err = checkIssuerPresent(authNRequest.Issuer)
+			return err
+		},
+		func() {
+			response.sendBackResponse(r, w, response.makeFailedResponse(StatusCodeRequestDenied, fmt.Errorf("failed to validate request: %w", err).Error(), p.TimeFormat))
 		},
 	)
 
@@ -306,10 +318,6 @@ func checkRequestRequiredContent(
 			return fmt.Errorf("version is missing in request")
 		}
 
-		if authNRequest.Issuer.Text == "" {
-			return fmt.Errorf("issuer is missing in request")
-		}
-
 		if authNRequest.Issuer.Text != sp.GetEntityID() {
 			return fmt.Errorf("issuer in request not equal entityID of service provider")
 		}
@@ -320,6 +328,14 @@ func checkRequestRequiredContent(
 
 		return nil
 	}
+}
+
+func checkIssuerPresent(issuer *saml.NameIDType) error {
+	if issuer == nil || issuer.Text == "" {
+		return fmt.Errorf("issuer is missing in request")
+	}
+
+	return nil
 }
 
 func certificateCheckNecessary(

--- a/pkg/provider/sso_test.go
+++ b/pkg/provider/sso_test.go
@@ -793,6 +793,40 @@ func TestSSO_ssoHandleFunc(t *testing.T) {
 				err:  false,
 			},
 		},
+		{
+			name: "redirect request without issuer",
+			args: args{
+				issuer:           "http://localhost:50002",
+				metadataEndpoint: "/saml/metadata",
+				config: &IdentityProviderConfig{
+					SignatureAlgorithm: dsig.RSASHA256SignatureMethod,
+					MetadataIDPConfig:  &MetadataIDPConfig{},
+					Endpoints: &EndpointConfig{
+						SingleSignOn: getEndpointPointer("/saml/SSO", "http://localhost:50002/saml/SSO"),
+					},
+				},
+				certificate: "-----BEGIN CERTIFICATE-----\nMIICvDCCAaQCCQD6E8ZGsQ2usjANBgkqhkiG9w0BAQsFADAgMR4wHAYDVQQDDBVt\neXNlcnZpY2UuZXhhbXBsZS5jb20wHhcNMjIwMjE3MTQwNjM5WhcNMjMwMjE3MTQw\nNjM5WjAgMR4wHAYDVQQDDBVteXNlcnZpY2UuZXhhbXBsZS5jb20wggEiMA0GCSqG\nSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7XKdCRxUZXjdqVqwwwOJqc1Ch0nOSmk+U\nerkUqlviWHdeLR+FolHKjqLzCBloAz4xVc0DFfR76gWcWAHJloqZ7GBS7NpDhzV8\nG+cXQ+bTU0Lu2e73zCQb30XUdKhWiGfDKaU+1xg9CD/2gIfsYPs3TTq1sq7oCs5q\nLdUHaVL5kcRaHKdnTi7cs5i9xzs3TsUnXcrJPwydjp+aEkyRh07oMpXBEobGisfF\n2p1MA6pVW2gjmywf7D5iYEFELQhM7poqPN3/kfBvU1n7Lfgq7oxmv/8LFi4Zopr5\nnyqsz26XPtUy1WqTzgznAmP+nN0oBTERFVbXXdRa3k2v4cxTNPn/AgMBAAEwDQYJ\nKoZIhvcNAQELBQADggEBAJYxROWSOZbOzXzafdGjQKsMgN948G/hHwVuZneyAcVo\nLMFTs1Weya9Z+snMp1u0AdDGmQTS9zGnD7syDYGOmgigOLcMvLMoWf5tCQBbEukW\n8O7DPjRR0XypChGSsHsqLGO0B0HaTel0HdP9Si827OCkc9Q+WbsFG/8/4ToGWL+u\nla1WuLawozoj8umPi9D8iXCoW35y2STU+WFQG7W+Kfdu+2CYz/0tGdwVqNG4Wsfa\nwWchrS00vGFKjm/fJc876gAfxiMH1I9fZvYSAxAZ3sVI//Ml2sUdgf067ywQ75oa\nLSS2NImmz5aos3vuWmOXhILd7iTU+BD8Uv6vWbI7I1M=\n-----END CERTIFICATE-----\n",
+				key:         "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC7XKdCRxUZXjdq\nVqwwwOJqc1Ch0nOSmk+UerkUqlviWHdeLR+FolHKjqLzCBloAz4xVc0DFfR76gWc\nWAHJloqZ7GBS7NpDhzV8G+cXQ+bTU0Lu2e73zCQb30XUdKhWiGfDKaU+1xg9CD/2\ngIfsYPs3TTq1sq7oCs5qLdUHaVL5kcRaHKdnTi7cs5i9xzs3TsUnXcrJPwydjp+a\nEkyRh07oMpXBEobGisfF2p1MA6pVW2gjmywf7D5iYEFELQhM7poqPN3/kfBvU1n7\nLfgq7oxmv/8LFi4Zopr5nyqsz26XPtUy1WqTzgznAmP+nN0oBTERFVbXXdRa3k2v\n4cxTNPn/AgMBAAECggEAF+rV9yH30Ysza8GwrXCR9qDN1Dp3QmmsavnXkonEvPoq\nEr2T3o0//6mBp6CLDboMQGQBjblJwl+3Y6PgZolvHAMOsMdHfYNPEo7FSzUBzEw+\nqRrs5HkMyvoPgfV6X8F97W3tiD4Q/AmHkMILl+MxbnfPXM54gWqPuwIqxY1uaCk5\nREwyb7WBon3rd58ceOI1SLRjod6SbqWBMMSN3cJ+5VEPObFjw/RlhNQ5rBI8G5Kt\nso2zBU5C4BB2CvqlWy98WDKJkTvWHbiTjZCy8BQ+gQ6UJM2vaNELFOVpuMGQnMIi\noWiX10Jg2e1gP9j3TdrohlGF8M3+TXjSFKNmeX0DUQKBgQDx7UazUWS5RtkgnjH9\nw2xH2xkstJVD7nAS8VTxNwcrgjVXPvTJha9El904obUjyRX7ppb02tuH5ML/bZh6\n9lL4bP5+SHcJ10e4q8CK/KAGHD6BYAbaGXRq0CoSk5a3vv5XPdob4T5qKCIHFpnu\nMfbvdbEoameLOyRYOGu/yVZIiwKBgQDGQs7FRTisHV0xooiRmlvYF0dcd19qpLed\nqhgJNqBPOTEvvGvJNRoi39haEY3cuTqsxZ5FAlFlVFMUUozz+d0xBLLInoVY/Y4h\nhSdGmdw/A6oHodLqyEp3N5RZNdLlh8/nDS3xXzMotAl75bW5kc2ttcRhRdtyNJ9Z\nup0PgppO3QKBgEC45upAQz8iCiKkz+EA8C4FGqYQJcLHvmoC8GOcAioMqrKNoDVt\ns2cZbdChynEpcd0iQ058YrDnbZeiPWHgFnBp0Gf+gQI7+u8X2+oTDci0s7Au/YZJ\nuxB8YlUX8QF1clvqqzg8OVNzKy9UR5gm+9YyWVPjq5HfH6kOZx0nAxNjAoGAERt8\nqgsCC9/wxbKnpCC0oh3IG5N1WUdjTKh7sHfVN2DQ/LR+fHsniTDVg1gWbKBTDsty\nj7PWgC7ZiFxjKz45NtyX7LW4/efLFttdezsVhR500nnFMFseCdFy7Iu3afThHKfH\nehdj27RFSTqWBrAtFjsj+dzERcOCqIRwvwDe/cUCgYEA5+1mzVXDVjKsWylKJPk+\nZZA4LUfvmTj3VLNDZrlSAI/xEikCFio0QWEA2TQYTAwbXTrKwQSeHQRhv7OTc1h+\nMhpAgvs189ze5J4jiNmULEkkrO+Cxxnw8tyV+UFRZtzW9gUoVBwXiZ/Wbl9sfnlO\nwLJHc0j6OltPcPJmxHP8gQI=\n-----END PRIVATE KEY-----\n",
+				request: request{
+					ID:          "test",
+					Binding:     RedirectBinding,
+					SAMLRequest: url.QueryEscape(generateSAMLRequestWithoutIssuer()),
+				},
+				sp: sp{
+					entityID: "http://localhost:8000/saml/metadata",
+					metadata: compactXML(`<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://localhost:8000/saml/metadata">
+					  <SPSSODescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="false" WantAssertionsSigned="true">
+					    <AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:8000/saml/acs" index="1"/>
+					  </SPSSODescriptor>
+					</EntityDescriptor>`),
+				},
+			},
+			res: res{
+				code:  200,
+				state: StatusCodeRequestDenied,
+				err:   false,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -927,6 +961,12 @@ func generateSAMLRequestWithACSIndex(index string) string {
     </saml:Issuer>
     <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" AllowCreate="true"/>
 </samlp:AuthnRequest>`, index))
+}
+
+func generateSAMLRequestWithoutIssuer() string {
+	return encodeSAMLRequestReadable(`<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="id-no-issuer" Version="2.0" IssueInstant="2024-01-01T00:00:00Z" Destination="http://localhost:50002/saml/SSO" AssertionConsumerServiceURL="http://localhost:8000/saml/acs" ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST">
+    <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" AllowCreate="true"/>
+</samlp:AuthnRequest>`)
 }
 
 func deflateAndEncodeSAMLRequest(xml string) string {


### PR DESCRIPTION
Adds nil checks for `AuthnRequestType.Issuer` and `LogoutRequestType.NameID` in the provider package. Otherwise – if the caller doesn't implement their own guards – leads to panics. 

### Definition of Ready

- [ ] I am happy with the code
- [ ] Short description of the feature/issue is added in the pr description
- [ ] PR is linked to the corresponding user story
- [ ] Acceptance criteria are met
- [ ] All open todos and follow ups are defined in a new ticket and justified
- [ ] Deviations from the acceptance criteria and design are agreed with the PO and documented.
- [ ] No debug or dead code
- [ ] My code has no repetitions
- [ ] Critical parts are tested automatically
- [ ] Where possible E2E tests are implemented
- [ ] Documentation/examples are up-to-date
- [ ] All non-functional requirements are met
- [ ] Functionality of the acceptance criteria is checked manually on the dev system.
